### PR TITLE
5.2 compatibility

### DIFF
--- a/src/lfs.c
+++ b/src/lfs.c
@@ -819,6 +819,15 @@ static const struct luaL_Reg fslib[] = {
 	{NULL, NULL},
 };
 
+#if LUA_VERSION_NUM > 501
+static void luaL_register (lua_State *L, const char *libname, const luaL_Reg *l)
+{
+	luaL_newlib (L, l);
+	lua_pushvalue (L, -1);
+	lua_setglobal (L, libname);
+}
+#endif
+
 int luaopen_lfs (lua_State *L) {
 	dir_create_meta (L);
 	lock_create_meta (L);


### PR DESCRIPTION
Lua 5.2 removed the luaL_register function. Using a preprocessor conditional for versions of Lua greater than 5.1, this patch will implement a suitable luaL_register so that luafilesystem will compile and work in these versions.
