### PR TITLE
Fix some warnings GCC produced on Linux

### DIFF
--- a/src/lfs.c
+++ b/src/lfs.c
@@ -119,7 +119,7 @@ typedef struct dir_data {
 #else
 #define _O_TEXT               0
 #define _O_BINARY             0
-#define lfs_setmode(L,file,m)   0
+#define lfs_setmode(L,file,m)   ((void)L, (void)file, (void)m, 0)
 #define STAT_STRUCT struct stat
 #define STAT_FUNC stat
 #define LSTAT_FUNC lstat


### PR DESCRIPTION
Fixes:
src/lfs.c:84:37: warning: C++ style comments are not allowed in ISO C90 [enabled by default]
src/lfs.c:84:37: warning: (this will be reported only once per input file) [enabled by default]
src/lfs.c: In function ‘lfs_g_setmode’:
src/lfs.c:324:7: warning: unused variable ‘op’ [-Wunused-variable]
src/lfs.c:321:47: warning: unused parameter ‘f’ [-Wunused-parameter]
