### PR TITLE
Fix. Use intptr_t to file handle on Windows (#26)

### DIFF
--- a/src/lfs.c
+++ b/src/lfs.c
@@ -94,7 +94,7 @@
 typedef struct dir_data {
         int  closed;
 #ifdef _WIN32
-        long hFile;
+        intptr_t hFile;
         char pattern[MAX_PATH+1];
 #else
         DIR *dir;


### PR DESCRIPTION
Tested on MS VS2008(x32) MinGW(x32) and MS VS2012(x64)
