### PR TITLE
Fix. Prevents double close the same handle (#24)

### DIFF
--- a/src/lfs.c
+++ b/src/lfs.c
@@ -281,7 +281,10 @@ static int lfs_lock_dir(lua_State *L) {
 }
 static int lfs_unlock_dir(lua_State *L) {
   lfs_Lock *lock = luaL_checkudata(L, 1, LOCK_METATABLE);
-  CloseHandle(lock->fd);
+  if(lock->fd != INVALID_HANDLE_VALUE) {    
+    CloseHandle(lock->fd);
+    lock->fd=INVALID_HANDLE_VALUE;
+  }
   return 0;
 }
 #else


### PR DESCRIPTION
lfs_unlock_dir can be called multiple times for the same object.
For example if lock:free is called manually.
Then lfs_unlock_dir will be called always
again, as soon as the LOCK_METATABLE is collected by GC.
This can lead to strange file errors later on, like closing
another file, which now has been assigned the same handle...
