### PR TITLE
Update luafilesystem-cvs-2.rockspec

### DIFF
--- a/rockspecs/luafilesystem-cvs-2.rockspec
+++ b/rockspecs/luafilesystem-cvs-2.rockspec
@@ -3,7 +3,8 @@ package = "LuaFileSystem"
 version = "cvs-2"
 
 source = {
-   url = "git://github.com/keplerproject/luafilesystem.git",
+   url = "https://github.com/keplerproject/luafilesystem/archive/master.zip",
+   dir = "luafilesystem-master",
 }
 
 description = {
@@ -17,10 +18,11 @@ description = {
 }
 
 dependencies = {
-   "lua >= 5.1"
+   "lua >= 5.1, < 5.3"
 }
 
 build = {
-   type = "module",
-   modules = { lfs = "src/lfs.c" }
+   type = "builtin",
+   modules = { lfs = "src/lfs.c" },
+   copy_directories = { "doc", "tests" }
 }


### PR DESCRIPTION
Use `https://` to retrieve source code because of LuaRocks supports it out of box.
Fix. Lua version in `dependencies`
