### PR TITLE
Minor fixes needed to compile LFS as C++

### DIFF
--- a/src/lfs.c
+++ b/src/lfs.c
@@ -292,7 +292,7 @@ static int lfs_lock_dir(lua_State *L) {
   return 1;
 }
 static int lfs_unlock_dir(lua_State *L) {
-  lfs_Lock *lock = luaL_checkudata(L, 1, LOCK_METATABLE);
+  lfs_Lock *lock = (lfs_Lock *)luaL_checkudata(L, 1, LOCK_METATABLE);
   if(lock->fd != INVALID_HANDLE_VALUE) {    
     CloseHandle(lock->fd);
     lock->fd=INVALID_HANDLE_VALUE;
@@ -325,7 +325,7 @@ static int lfs_lock_dir(lua_State *L) {
   return 1;
 }
 static int lfs_unlock_dir(lua_State *L) {
-  lfs_Lock *lock = luaL_checkudata(L, 1, LOCK_METATABLE);
+  lfs_Lock *lock = (lfs_Lock *)luaL_checkudata(L, 1, LOCK_METATABLE);
   if(lock->ln) {
     unlink(lock->ln);
     free(lock->ln);

--- a/src/lfs.h
+++ b/src/lfs.h
@@ -21,5 +21,12 @@
 #define fileno(f) (_fileno(f))
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 int luaopen_lfs (lua_State *L);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
A few minor things fixed which prevented compilation of LuaFileSystem as C++ code (useful when Lua is compiled as C++ as well).