### PR TITLE
DEF file fixes

### DIFF
--- a/src/lfs.def
+++ b/src/lfs.def
@@ -1,5 +1,4 @@
 LIBRARY lfs.dll
-DESCRIPTION "LuaFileSystem"
-VERSION 1.5.0
+VERSION 1.6
 EXPORTS
 luaopen_lfs


### PR DESCRIPTION
Fixed a few problems with a DEF file that produced warning/errors:

1) DESCRIPTION is deprecated, it was never intended for DLLs in the first place (see https://msdn.microsoft.com/en-us/library/aa984816%28v=vs.71%29.aspx, https://msdn.microsoft.com/en-us/library/k1wttw46%28v=vs.71%29.aspx)

2) VERSION must contain either one or two numbers (https://msdn.microsoft.com/en-us/library/t9cc0ax3%28v=vs.120%29.aspx). Otherwise errors are reported by both MinGW and MSVC 2013 Community Edition.
