### PR TITLE
Fix detection of closed files on Lua 5.2/5.3.

### DIFF
--- a/src/lfs.c
+++ b/src/lfs.c
@@ -197,15 +197,23 @@ static int get_dir (lua_State *L) {
 ** Check if the given element on the stack is a file and returns it.
 */
 static FILE *check_file (lua_State *L, int idx, const char *funcname) {
+#if LUA_VERSION_NUM == 501
         FILE **fh = (FILE **)luaL_checkudata (L, idx, "FILE*");
-        if (fh == NULL) {
-                luaL_error (L, "%s: not a file", funcname);
-                return 0;
-        } else if (*fh == NULL) {
+        if (*fh == NULL) {
                 luaL_error (L, "%s: closed file", funcname);
                 return 0;
         } else
                 return *fh;
+#elif LUA_VERSION_NUM >= 502 && LUA_VERSION_NUM <= 503
+        luaL_Stream *fh = (luaL_Stream *)luaL_checkudata (L, idx, "FILE*");
+        if (fh->closef == 0 || fh->f == NULL) {
+                luaL_error (L, "%s: closed file", funcname);
+                return 0;
+        } else
+                return fh->f;
+#else
+#error unsupported Lua version
+#endif
 }
 
 


### PR DESCRIPTION
Lua 5.2 changed the protocol on how to represent closed files: Lua 5.1 sets the file pointer to NULL, Lua 5.2 sets the close function pointer to NULL (a NULL file pointer now signals an incompletely constructed object, the default close functions do **not** set the file pointer to NULL).
Also `luaL_checkudata` never returns NULL, it raises an error instead if you have an invalid value (no userdata/not correct userdata type).