### PR TITLE
Have make_link() use pushresult() instead of pusherror() on Windows

### DIFF
--- a/src/lfs.c
+++ b/src/lfs.c
@@ -431,7 +431,8 @@ static int make_link(lua_State *L)
         return pushresult(L,
                 (lua_toboolean(L,3) ? symlink : link)(oldpath, newpath), NULL);
 #else
-        return pusherror(L, "make_link is not supported on Windows");
+        errno = ENOSYS; /* = "Function not implemented" */
+        return pushresult(L, -1, "make_link is not supported on Windows");
 #endif
 }
 


### PR DESCRIPTION
The pushresult(L, -1, ...) call will delegate to pusherror() anyway,
but this avoids the "Unused static" warning for pushresult.

Also take care of assigning something meaningful to `errno`, as
strerror(errno) is used for constructing the Lua error message.

Fixes #65