### PR TITLE
Delete $(CFLAGS) in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ OBJS= src/$T.o
 lib: src/lfs.so
 
 src/lfs.so: $(OBJS)
-	MACOSX_DEPLOYMENT_TARGET="10.3"; export MACOSX_DEPLOYMENT_TARGET; $(CC) $(CFLAGS) $(LIB_OPTION) -o src/lfs.so $(OBJS)
+	MACOSX_DEPLOYMENT_TARGET="10.3"; export MACOSX_DEPLOYMENT_TARGET; $(CC) $(LIB_OPTION) -o src/lfs.so $(OBJS)
 
 test: lib
 	LUA_CPATH=./src/?.so lua tests/test.lua


### PR DESCRIPTION
$(CC) $(CFLAGS) $(LIB_OPTION) -o src/lfs.so $(OBJS)
->
$(CC) $(LIB_OPTION) -o src/lfs.so $(OBJS)

I changed config:
CFLAGS= $(WARN) $(INCS)
->
CFLAGS= $(WARN) $(INCS) -x c++ -std=gnu++11

Then make error:
g++ ... -x c++ -std=gnu++11 ... -o src/lfs.so src/lfs.o
src/lfs.o:1:1: error: stray '\177' in program
ELF ...

