### PR TITLE
Return errno from more functions and other return/error value changes

### DIFF
--- a/doc/us/manual.html
+++ b/doc/us/manual.html
@@ -104,7 +104,7 @@ LuaFileSystem offers the following functions:
 <dl class="reference">
     <dt><a name="attributes"></a><strong><code>lfs.attributes (filepath [, aname])</code></strong></dt>
     <dd>Returns a table with the file attributes corresponding to
-    <code>filepath</code> (or <code>nil</code> followed by an error message
+    <code>filepath</code> (or <code>nil</code> followed by an error message and a system-dependent error code
     in case of error).
     If the second optional argument is given, then only the value of the
     named attribute is returned (this use is equivalent to
@@ -216,19 +216,21 @@ LuaFileSystem offers the following functions:
     and the second is the name of the link. If the optional third
     argument is true, the link will by a symbolic link (by default, a
     hard link is created).
+    Returns <code>true</code> in case of success or <code>nil</code>, an error message and
+    a system-dependent error code in case of error.
     </dd>
     
     <dt><a name="mkdir"></a><strong><code>lfs.mkdir (dirname)</code></strong></dt>
     <dd>Creates a new directory. The argument is the name of the new
     directory.<br />
-    Returns <code>true</code> if the operation was successful;
-    in case of error, it returns <code>nil</code> plus an error string.
+    Returns <code>true</code> in case of success or <code>nil</code>, an error message and
+    a system-dependent error code in case of error.
     </dd>
     
     <dt><a name="rmdir"></a><strong><code>lfs.rmdir (dirname)</code></strong></dt>
     <dd>Removes an existing directory. The argument is the name of the directory.<br />
-    Returns <code>true</code> if the operation was successful;
-    in case of error, it returns <code>nil</code> plus an error string.</dd>
+    Returns <code>true</code> in case of success or <code>nil</code>, an error message and
+    a system-dependent error code in case of error.
 
     <dt><a name="setmode"></a><strong><code>lfs.setmode (file, mode)</code></strong></dt>
     <dd>Sets the writing mode for a file. The mode string can be either <code>"binary"</code> or <code>"text"</code>.
@@ -254,8 +256,8 @@ LuaFileSystem offers the following functions:
     Lua standard function <code>os.time</code>).
     If the modification time is omitted, the access time provided is used;
     if both times are omitted, the current time is used.<br />
-    Returns <code>true</code> if the operation was successful;
-    in case of error, it returns <code>nil</code> plus an error string.
+    Returns <code>true</code> in case of success or <code>nil</code>, an error message and
+    a system-dependent error code in case of error.
     </dd>
     
     <dt><a name="unlock"></a><strong><code>lfs.unlock (filehandle[, start[, length]])</code></strong></dt>

--- a/src/lfs.c
+++ b/src/lfs.c
@@ -133,6 +133,13 @@ typedef struct dir_data {
 #define LSTAT_FUNC lstat
 #endif
 
+#ifdef _WIN32
+  #define lfs_mkdir _mkdir
+#else
+  #define lfs_mkdir(path) (mkdir((path), \
+    S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IWGRP | S_IXGRP | S_IROTH | S_IXOTH))
+#endif
+
 /*
 ** Utility functions
 */
@@ -437,21 +444,8 @@ static int make_link(lua_State *L)
 ** @param #1 Directory path.
 */
 static int make_dir (lua_State *L) {
-        const char *path = luaL_checkstring (L, 1);
-        int fail;
-#ifdef _WIN32
-        fail = _mkdir (path);
-#else
-        fail =  mkdir (path, S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP |
-                             S_IWGRP | S_IXGRP | S_IROTH | S_IXOTH );
-#endif
-        if (fail) {
-                lua_pushnil (L);
-        lua_pushfstring (L, "%s", strerror(errno));
-                return 2;
-        }
-        lua_pushboolean (L, 1);
-        return 1;
+  const char *path = luaL_checkstring(L, 1);
+  return pushresult(L, lfs_mkdir(path), NULL);
 }
 
 

--- a/src/lfs.c
+++ b/src/lfs.c
@@ -642,26 +642,24 @@ static const char *mode2string (mode_t mode) {
 
 
 /*
-** Set access time and modification values for file
+** Set access time and modification values for a file.
+** @param #1 File path.
+** @param #2 Access time in seconds, current time is used if missing.
+** @param #3 Modification time in seconds, access time is used if missing.
 */
 static int file_utime (lua_State *L) {
-        const char *file = luaL_checkstring (L, 1);
-        struct utimbuf utb, *buf;
+  const char *file = luaL_checkstring(L, 1);
+  struct utimbuf utb, *buf;
 
-        if (lua_gettop (L) == 1) /* set to current date/time */
-                buf = NULL;
-        else {
-                utb.actime = (time_t)luaL_optnumber (L, 2, 0);
-                utb.modtime = (time_t) luaL_optinteger (L, 3, utb.actime);
-                buf = &utb;
-        }
-        if (utime (file, buf)) {
-                lua_pushnil (L);
-                lua_pushfstring (L, "%s", strerror (errno));
-                return 2;
-        }
-        lua_pushboolean (L, 1);
-        return 1;
+  if (lua_gettop (L) == 1) /* set to current date/time */
+    buf = NULL;
+  else {
+    utb.actime = (time_t) luaL_optnumber(L, 2, 0);
+    utb.modtime = (time_t) luaL_optinteger(L, 3, utb.actime);
+    buf = &utb;
+  }
+
+  return pushresult(L, utime(file, buf), NULL);
 }
 
 

--- a/src/lfs.c
+++ b/src/lfs.c
@@ -454,18 +454,8 @@ static int make_dir (lua_State *L) {
 ** @param #1 Directory path.
 */
 static int remove_dir (lua_State *L) {
-        const char *path = luaL_checkstring (L, 1);
-        int fail;
-
-        fail = rmdir (path);
-
-        if (fail) {
-                lua_pushnil (L);
-                lua_pushfstring (L, "%s", strerror(errno));
-                return 2;
-        }
-        lua_pushboolean (L, 1);
-        return 1;
+  const char *path = luaL_checkstring(L, 1);
+  return pushresult(L, rmdir(path), NULL);
 }
 
 

--- a/src/lfs.c
+++ b/src/lfs.c
@@ -147,12 +147,13 @@ static int pusherror(lua_State *L, const char *info)
         return 3;
 }
 
-static int pushresult(lua_State *L, int i, const char *info)
-{
-        if (i==-1)
-                return pusherror(L, info);
-        lua_pushinteger(L, i);
-        return 1;
+static int pushresult(lua_State *L, int res, const char *info) {
+  if (res == -1) {
+    return pusherror(L, info);
+  } else {
+    lua_pushboolean(L, 1);
+    return 1;
+  }
 }
 
 

--- a/src/lfs.c
+++ b/src/lfs.c
@@ -794,9 +794,10 @@ static int _file_info_ (lua_State *L, int (*st)(const char*, STAT_STRUCT*)) {
         int i;
 
         if (st(file, &info)) {
-                lua_pushnil (L);
-                lua_pushfstring (L, "cannot obtain information from file `%s'", file);
-                return 2;
+                lua_pushnil(L);
+                lua_pushfstring(L, "cannot obtain information from file '%s': %s", file, strerror(errno));
+                lua_pushinteger(L, errno);
+                return 3;
         }
         if (lua_isstring (L, 2)) {
                 const char *member = lua_tostring (L, 2);

--- a/src/lfs.c
+++ b/src/lfs.c
@@ -808,7 +808,7 @@ static int _file_info_ (lua_State *L, int (*st)(const char*, STAT_STRUCT*)) {
                         }
                 }
                 /* member not found */
-                return luaL_error(L, "invalid attribute name");
+                return luaL_error(L, "invalid attribute name '%s'", member);
         }
         /* creates a table if none is given */
         if (!lua_istable (L, 2)) {

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -88,7 +88,9 @@ io.write(".")
 io.flush()
 
 -- Checking link (does not work on Windows)
-if lfs.link (tmpfile, "_a_link_for_test_", true) then
+local link_ok = lfs.link (tmpfile, "_a_link_for_test_", true)
+if link_ok then
+  assert (link_ok == true, "successful lfs.link did not return true")
   assert (lfs.attributes"_a_link_for_test_".mode == "file")
   assert (lfs.symlinkattributes"_a_link_for_test_".mode == "link")
   assert (lfs.link (tmpfile, "_a_hard_link_for_test_"))

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -138,7 +138,10 @@ io.write(".")
 io.flush()
 
 -- Trying to get attributes of a non-existent file
-assert (lfs.attributes ("this couldn't be an actual file") == nil, "could get attributes of a non-existent file")
+local attr_ok, err, errno = lfs.attributes("this couldn't be an actual file")
+assert(attr_ok == nil, "could get attributes of a non-existent file")
+assert(type(err) == "string", "failed lfs.attributes did not return an error message")
+assert(type(errno) == "number", "failed lfs.attributes did not return error code")
 assert (type(lfs.attributes (upper)) == "table", "couldn't get attributes of upper directory")
 
 io.write(".")


### PR DESCRIPTION
* Return `errno` as the third value on error in `lfs.attributes`, `lfs.mkdir`, `lfs.rmdir`, `lfs.link`.
* Show `strerror(errno)` in error messages for `lfs.attributes`.
* Show attribute name on invalid attribute in `lfs.attributes`.
* Return `true` instead of `0` on success in `lfs.link`.
* Add not enough tests and update docs.