### PR TITLE
Add a 'target' field for symlinkattributes

### DIFF
--- a/doc/us/manual.html
+++ b/doc/us/manual.html
@@ -242,6 +242,8 @@ LuaFileSystem offers the following functions:
     <dt><a name="symlinkattributes"></a><strong><code>lfs.symlinkattributes (filepath [, aname])</code></strong></dt>
     <dd>Identical to <a href="#attributes">lfs.attributes</a> except that
     it obtains information about the link itself (not the file it refers to).
+    It also adds a <strong><code>target</code></strong> field, containing
+    the file name that the symlink points to.
     On Windows this function does not yet support links, and is identical to
     <code>lfs.attributes</code>.
     </dd>

--- a/src/lfs.c
+++ b/src/lfs.c
@@ -850,10 +850,72 @@ static int file_info (lua_State *L) {
 
 
 /*
+** Push the symlink target to the top of the stack.
+** Assumes the file name is at position 1 of the stack.
+** Returns 1 if successful (with the target on top of the stack),
+** 0 on failure (with stack unchanged, and errno set).
+*/
+static int push_link_target(lua_State *L) {
+#ifdef _WIN32
+        errno = ENOSYS;
+        return 0;
+#else
+        const char *file = luaL_checkstring(L, 1);
+        char *target;
+        int size, tsize;
+        if (lua_type(L, -1) == LUA_TTABLE) {
+                /* when symlinkattributes collects the whole table,
+                   get the size from it */
+                int size_type = lua_getfield(L, -1, "size");
+                if (size_type != LUA_TNUMBER) {
+                        lua_pop(L, 1);
+                        errno = EINVAL;
+                        return 0;
+                }
+                size = lua_tointeger(L, -1);
+                lua_pop(L, 1);
+        } else {
+                /* when we are just getting 'target', we need to run
+                   lstat ourselves to get the size */
+                STAT_STRUCT info;
+                if (LSTAT_FUNC(file, &info)) {
+                        return 0;
+                }
+                size = info.st_size;
+        }
+        target = (char*) malloc(size + 1);
+        if (!target) {
+                return 0;
+        }
+        tsize = readlink(file, target, size);
+        if (tsize != size) {
+                free(target);
+                return 0;
+        }
+        target[tsize] = '\0';
+        lua_pushlstring(L, target, tsize);
+        free(target);
+        return 1;
+#endif
+}
+
+/*
 ** Get symbolic link information using lstat.
 */
 static int link_info (lua_State *L) {
-        return _file_info_ (L, LSTAT_FUNC);
+        int ret;
+        if (lua_isstring (L, 2) && (strcmp(lua_tostring(L, 2), "target") == 0)) {
+                int ok = push_link_target(L);
+                return ok ? 1 : pusherror(L, "could not obtain link target");
+        }
+        ret = _file_info_ (L, LSTAT_FUNC);
+        if (ret == 1 && lua_type(L, -1) == LUA_TTABLE) {
+                int ok = push_link_target(L);
+                if (ok) {
+                        lua_setfield(L, -2, "target");
+                }
+        }
+        return ret;
 }
 
 

--- a/src/lfs.c
+++ b/src/lfs.c
@@ -866,7 +866,8 @@ static int push_link_target(lua_State *L) {
         if (lua_type(L, -1) == LUA_TTABLE) {
                 /* when symlinkattributes collects the whole table,
                    get the size from it */
-                int size_type = lua_getfield(L, -1, "size");
+                lua_getfield(L, -1, "size");
+                int size_type = lua_type(L, -1);
                 if (size_type != LUA_TNUMBER) {
                         lua_pop(L, 1);
                         errno = EINVAL;

--- a/src/lfs.c
+++ b/src/lfs.c
@@ -887,7 +887,7 @@ static const struct luaL_Reg fslib[] = {
         {NULL, NULL},
 };
 
-int luaopen_lfs (lua_State *L) {
+LFS_EXPORT int luaopen_lfs (lua_State *L) {
         dir_create_meta (L);
         lock_create_meta (L);
         luaL_newlib (L, fslib);

--- a/src/lfs.h
+++ b/src/lfs.h
@@ -5,27 +5,29 @@
 
 /* Define 'chdir' for systems that do not implement it */
 #ifdef NO_CHDIR
-#define chdir(p)	(-1)
-#define chdir_error	"Function 'chdir' not provided by system"
+  #define chdir(p)	(-1)
+  #define chdir_error	"Function 'chdir' not provided by system"
 #else
-#define chdir_error	strerror(errno)
-
+  #define chdir_error	strerror(errno)
 #endif
 
 #ifdef _WIN32
-#define chdir(p) (_chdir(p))
-#define getcwd(d, s) (_getcwd(d, s))
-#define rmdir(p) (_rmdir(p))
-#ifndef fileno
-#define fileno(f) (_fileno(f))
-#endif
+  #define chdir(p) (_chdir(p))
+  #define getcwd(d, s) (_getcwd(d, s))
+  #define rmdir(p) (_rmdir(p))
+  #define LFS_EXPORT __declspec (dllexport)
+  #ifndef fileno
+    #define fileno(f) (_fileno(f))
+  #endif
+#else
+  #define LFS_EXPORT
 #endif
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-int luaopen_lfs (lua_State *L);
+LFS_EXPORT  int luaopen_lfs (lua_State *L);
 
 #ifdef __cplusplus
 }

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -91,6 +91,8 @@ io.flush()
 if lfs.link (tmpfile, "_a_link_for_test_", true) then
   assert (lfs.attributes"_a_link_for_test_".mode == "file")
   assert (lfs.symlinkattributes"_a_link_for_test_".mode == "link")
+  assert (lfs.symlinkattributes"_a_link_for_test_".target == tmpfile)
+  assert (lfs.symlinkattributes("_a_link_for_test_", "target") == tmpfile)
   assert (lfs.link (tmpfile, "_a_hard_link_for_test_"))
   assert (lfs.attributes (tmpfile, "nlink") == 2)
   assert (os.remove"_a_link_for_test_")

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -107,6 +107,9 @@ assert(result) -- on non-Windows platforms, mode is always returned as "binary"
 result, mode = lfs.setmode(f, "text")
 assert(result and mode == "binary")
 f:close()
+local ok, err = pcall(lfs.setmode, f, "binary")
+assert(not ok, "could setmode on closed file")
+assert(err:find("closed file"), "bad error message for setmode on closed file")
 
 io.write(".")
 io.flush()


### PR DESCRIPTION
It returns the resolved path of the symlink.

Since this adds functionality, this should be merged in the 1.7 branch. PRing for review.