### PR TITLE
Add a 'target' field for symlinkattributes.

### DIFF
--- a/doc/us/manual.html
+++ b/doc/us/manual.html
@@ -242,6 +242,8 @@ LuaFileSystem offers the following functions:
     <dt><a name="symlinkattributes"></a><strong><code>lfs.symlinkattributes (filepath [, aname])</code></strong></dt>
     <dd>Identical to <a href="#attributes">lfs.attributes</a> except that
     it obtains information about the link itself (not the file it refers to).
+    It also adds a <strong><code>target</code></strong> field, containing
+    the file name that the symlink points to.
     On Windows this function does not yet support links, and is identical to
     <code>lfs.attributes</code>.
     </dd>

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -91,6 +91,8 @@ io.flush()
 if lfs.link (tmpfile, "_a_link_for_test_", true) then
   assert (lfs.attributes"_a_link_for_test_".mode == "file")
   assert (lfs.symlinkattributes"_a_link_for_test_".mode == "link")
+  assert (lfs.symlinkattributes"_a_link_for_test_".target == tmpfile)
+  assert (lfs.symlinkattributes("_a_link_for_test_", "target") == tmpfile)
   assert (lfs.link (tmpfile, "_a_hard_link_for_test_"))
   assert (lfs.attributes (tmpfile, "nlink") == 2)
   assert (os.remove"_a_link_for_test_")


### PR DESCRIPTION
This PR is based on the previous version by @hishamhm in #76, but uses a different strategy for 'dynamically' sizing the buffer.