### PR TITLE
Add Windows compatibility for lfs.link

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -13,7 +13,7 @@ lib: src\lfs.dll
 	$(CC) /c /Fo$@ $(CFLAGS) $<
 
 src\lfs.dll: $(OBJS)
-	link /dll /def:src\$T.def /out:src\lfs.dll $(OBJS) "$(LUA_LIB)"
+	link /dll /def:src\$T.def /out:src\lfs.dll $(OBJS) "$(LUA_LIB)" "$(WIN_LIBS)"
 	IF EXIST src\lfs.dll.manifest mt -manifest src\lfs.dll.manifest -outputresource:src\lfs.dll;2
 
 install: src\lfs.dll

--- a/config.win
+++ b/config.win
@@ -8,6 +8,9 @@ LUA_INC= "c:\lua5.1\include"
 # Lua library
 LUA_LIB= "c:\lua5.1\lua5.1.lib"
 
+# Windows library
+WIN_LIBS = "Shlwapi.lib"
+
 LIBNAME= $T.dll
 
 # Compilation directives

--- a/src/lfs.c
+++ b/src/lfs.c
@@ -43,6 +43,7 @@
 #ifdef _WIN32
   #include <direct.h>
   #include <windows.h>
+  #include "Shlwapi.h"
   #include <io.h>
   #include <sys/locking.h>
   #ifdef __BORLANDC__
@@ -431,19 +432,34 @@ static int file_unlock (lua_State *L) {
 ** @param #3 True if link is symbolic (optional).
 */
 static int make_link (lua_State *L) {
+        const char *oldpath = luaL_checkstring(L, 1);
+        const char *newpath = luaL_checkstring(L, 2);
 #ifndef _WIN32
-  const char *oldpath = luaL_checkstring(L, 1);
-  const char *newpath = luaL_checkstring(L, 2);
-  int res = (lua_toboolean(L,3) ? symlink : link)(oldpath, newpath);
-  if (res == -1) {
-    return pusherror(L, NULL);
-  } else {
-    lua_pushinteger(L, 0);
-    return 1;
-  }
+        int res = (lua_toboolean(L, 3) ? symlink : link)(oldpath, newpath);
+        if (res == -1) {
+                return pusherror(L, NULL);
+        } else {
+               lua_pushinteger(L, 0);
+               return 1;
+        }
 #else
-  errno = ENOSYS; /* = "Function not implemented" */
-  return pushresult(L, -1, "make_link is not supported on Windows");
+        int symlink = lua_toboolean(L, 3);
+        int is_dir = PathIsDirectory(oldpath) == FILE_ATTRIBUTE_DIRECTORY;
+        if (is_dir && !symlink) {
+                lua_pushnil(L); lua_pushstring(L, "hard links to directories are not supported on Windows");
+                return 2;
+        }
+
+        int result = symlink ? CreateSymbolicLink(newpath, oldpath, is_dir)
+                             : CreateHardLink(newpath, oldpath, NULL);
+
+        if (result) {
+                return pushresult(L, result, NULL);
+        } else {
+                lua_pushnil(L); lua_pushstring(L, symlink ? "make_link CreateSymbolicLink() failed"
+                                                          : "make_link CreateHardLink() failed");
+                return 2;
+        }
 #endif
 }
 


### PR DESCRIPTION
This allows LFS to create symbolic and hard links on Windows.

On Windows, hard links may not be created to directories, so this function first uses `PathIsDirectory` to check whether the link target is a directory. This function is included in "Shlwapi.h" (Shell Path Handling Functions). I included this file in the Windows build files as well.

Unfortunately, this breaks `test.lua` on Windows now because links are being created, but `symlinkattributes` still cannot return the correct mode. If time permits, I'll add a Windows function that checks for link targets in the future.

I wasn't sure whether 1.7 or the master branch is the better target for this pull request. Feel free to correct me or to tell me any other suggestions!