### PR TITLE
Use CREATE_ALWAYS instead of CREATE_NEW

### DIFF
--- a/src/lfs.c
+++ b/src/lfs.c
@@ -299,7 +299,7 @@ static int lfs_lock_dir(lua_State *L) {
     lua_pushnil(L); lua_pushstring(L, strerror(errno)); return 2;
   }
   strcpy(ln, path); strcat(ln, lockfile);
-  if((fd = CreateFile(ln, GENERIC_WRITE, 0, NULL, CREATE_NEW,
+  if((fd = CreateFile(ln, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS,
                 FILE_ATTRIBUTE_NORMAL | FILE_FLAG_DELETE_ON_CLOSE, NULL)) == INVALID_HANDLE_VALUE) {
         int en = GetLastError();
         free(ln); lua_pushnil(L);


### PR DESCRIPTION
CREATE_ALWAYS is better than CREATE_NEW for dir locking IMHO, because lockfile.lfs may be not deleted in some cases.