### PR TITLE
Make MACOSX_DEPLOYMENT_TARGET configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ OBJS= src/$T.o
 lib: src/lfs.so
 
 src/lfs.so: $(OBJS)
-	MACOSX_DEPLOYMENT_TARGET="10.3"; export MACOSX_DEPLOYMENT_TARGET; $(CC) $(LIB_OPTION) -o src/lfs.so $(OBJS)
+	MACOSX_DEPLOYMENT_TARGET=$(MACOSX_DEPLOYMENT_TARGET); export MACOSX_DEPLOYMENT_TARGET; $(CC) $(LIB_OPTION) -o src/lfs.so $(OBJS)
 
 test: lib
 	LUA_CPATH=./src/?.so lua tests/test.lua

--- a/config
+++ b/config
@@ -14,6 +14,9 @@ LUA_INC += -I/usr/include/lua5.1
 LIB_OPTION= -shared #for Linux
 #LIB_OPTION= -bundle -undefined dynamic_lookup #for MacOS X
 
+# Minimum runtime OS version on macOS
+MACOSX_DEPLOYMENT_TARGET= 10.5
+
 LIBNAME= $T.so.$V
 
 # Compilation directives


### PR DESCRIPTION
Also increase the default target to 10.5, since Xcode 10 can no longer
target 10.3.