### PR TITLE
Fallback to _POSIX_PATH_MAX when MAXPATHLEN isn't available

### DIFF
--- a/src/lfs.c
+++ b/src/lfs.c
@@ -60,7 +60,12 @@
   #include <sys/types.h>
   #include <utime.h>
   #include <sys/param.h> /* for MAXPATHLEN */
-  #define LFS_MAXPATHLEN MAXPATHLEN
+  #ifdef MAXPATHLEN
+    #define LFS_MAXPATHLEN MAXPATHLEN
+  #else
+    #include <limits.h> /* for _POSIX_PATH_MAX */
+    #define LFS_MAXPATHLEN _POSIX_PATH_MAX
+  #endif
 #endif
 
 #include <lua.h>


### PR DESCRIPTION
On systems where MAXPATHLEN isn't defined, like GNU/Hurd, use _POSIX_PATH_MAX as the starting size for the getcwd() buffer.

---
This is a patch we've been carrying in Debian since 2014.