### PR TITLE
add cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,20 @@
+PROJECT(lfs C)
+cmake_minimum_required(VERSION 2.8)
+
+if(WIN32)
+add_definitions(-DLUA_BUILD_AS_DLL -DLUA_LIB)
+endif()
+
+if(WIN32)
+set(LUA_LIBRARY_L ${LUA_LIB})
+else()
+set(LUA_LIBRARY_L "")
+endif()
+
+INCLUDE_DIRECTORIES(${LUA_INC})
+
+ADD_LIBRARY(lfs SHARED src/lfs.c)
+set_target_properties(lfs PROPERTIES PREFIX "")
+TARGET_LINK_LIBRARIES(lfs ${LUA_LIBRARY_L})
+
+INSTALL (TARGETS lfs RUNTIME DESTINATION ${LUA_LIBDIR} LIBRARY DESTINATION ${LUA_LIBDIR})


### PR DESCRIPTION
This allows building with

cmake -G"MinGW Makefiles" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DLUA_LIB=c:/anima/lua51.dll -DLUA_INC=C:/supercolliderrepos/Lua2SC/lua-5.1.5/src -DLUA_LIBDIR=c:/anima ../../luafilesystem

mingw32-make install

Of course it will work with other compilers, system, toolchains setting
LUA_LIB
LUA_INC
LUA_LIBDIR

and using make install, nmake install or whatever

Tested on win32 mingw, win32 nmake(MSVC) and linux gcc