### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: c
 
+arch:
+ - amd64
+ - ppc64le
+ 
 sudo: false
 
 env:
@@ -7,6 +11,10 @@ env:
   - LUA="lua 5.2"
   - LUA="lua 5.3"
   - LUA="luajit 2.1"
+jobs:
+  exclude:
+      - arch: ppc64le
+        env: LUA="luajit 2.1"
 
 before_install:
   - pip install --user cpp-coveralls hererocks


### PR DESCRIPTION
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3
Added ppc64le arch and excluded env luajit 2.1 for ppc64le arch