### PR TITLE
rockspec: use git+https:// for git repository URL

### DIFF
--- a/luafilesystem-scm-1.rockspec
+++ b/luafilesystem-scm-1.rockspec
@@ -1,7 +1,7 @@
 package = "luafilesystem"
 version = "scm-1"
 source = {
-   url = "git://github.com/keplerproject/luafilesystem"
+   url = "git+https://github.com/keplerproject/luafilesystem"
 }
 description = {
    summary = "File System Library for the Lua Programming Language",


### PR DESCRIPTION
GitHub is going to disable unencrypted Git protocol, so `git://` URLs
will stop working soon (see [1]).

[1]: https://github.blog/2021-09-01-improving-git-protocol-security-github/