### PR TITLE
Support Lua 5.5

### DIFF
--- a/src/lfs.c
+++ b/src/lfs.c
@@ -311,7 +311,7 @@ static FILE *check_file(lua_State * L, int idx, const char *funcname)
     return 0;
   } else
     return *fh;
-#elif LUA_VERSION_NUM >= 502 && LUA_VERSION_NUM <= 504
+#elif LUA_VERSION_NUM >= 502 && LUA_VERSION_NUM <= 505
   luaL_Stream *fh = (luaL_Stream *) luaL_checkudata(L, idx, "FILE*");
   if (fh->closef == 0 || fh->f == NULL) {
     luaL_error(L, "%s: closed file", funcname);


### PR DESCRIPTION
This adds support for the upcoming [Lua 5.5](https://www.lua.org/work/).

The only change is incrementing a version number check in `static FILE *check_file()`.

Tests pass on my machine with a build from [the Lua Github repo](https://github.com/lua/lua).

```console
$ make test
LuaFileSystem 1.8.0
.............Ok!
```
