### PR TITLE
ci: add Lua 5.5 to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   TestMatrix:
     strategy:
       matrix:
-        lua-version: ["5.4", "5.3", "5.2", "5.1", "luajit"]
+        lua-version: ["5.5", "5.4", "5.3", "5.2", "5.1", "luajit"]
         os: ["ubuntu-latest"]
         libflag: ["-shared --coverage"]
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,11 @@ jobs:
         libflag: ["-shared --coverage"]
         include:
         - os: "macos-latest"
-          lua-version: "5.4"
+          lua-version: "5.5"
           libflag: "-bundle -undefined dynamic_lookup -all_load --coverage"
         - os: "windows-latest"
           toolchain: "msvc"
-          lua-version: "5.4"
+          lua-version: "5.5"
         - os: "windows-latest"
           lua-version: "luajit"
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Hey 👋 

With Lua 5.5 (built with Nix), I'm running into a `dynamic libraries not enabled; check your Lua installation` error when I try to `require('lfs')`.
Strangely, it doesn't occur with Lua < 5.5.

So I figured I'd add Lua 5.5 to the CI's test matrix here to figure out if it's a nix-specific issue :smile: 